### PR TITLE
Added @CCob's dnMerge nuget package

### DIFF
--- a/ForgeCert/ForgeCert.csproj
+++ b/ForgeCert/ForgeCert.csproj
@@ -11,6 +11,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -57,4 +59,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\dnMerge.0.5.15\build\dnMerge.targets" Condition="Exists('..\packages\dnMerge.0.5.15\build\dnMerge.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\dnMerge.0.5.15\build\dnMerge.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\dnMerge.0.5.15\build\dnMerge.targets'))" />
+  </Target>
 </Project>

--- a/ForgeCert/packages.config
+++ b/ForgeCert/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="BouncyCastle" version="1.8.9" targetFramework="net45" />
   <package id="CommandLineParser" version="2.8.0" targetFramework="net45" />
+  <package id="dnMerge" version="0.5.15" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Added @CCob's dnMerge NuGet package, merges the .NET reference assemblies into a single binary. Below 950kb, so Cobalt execution should be fine!