### PR TITLE
Added KDC_ERR_CLIENT_NOT_TRUSTED problem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Done. Saved forged certificate to localadmin.pfx with the password 'NewPassword1
 
 This forgery can be done on an attacker-controlled system, and the resulting certificate can be used with [Rubeus](https://github.com/GhostPack/Rubeus) to request a TGT (and/or retrieve the user's NTLM ;)
 
+If you get the `KRB-ERROR (62) : KDC_ERR_CLIENT_NOT_TRUSTED` when requesting the TGT with Rubeus, try forging your certificate with a CRL (`--CRL <LDAP_PATH>`).
 
 ## Defensive Considerations
 


### PR DESCRIPTION
Hi, thank you for your useful tool. I recently tried out your tool in a lab and ran into the `KDC_ERR_CLIENT_NOT_TRUSTED` error. It took me a bunch of time to find out that the CRL flag is needed to bypass this error, at least according to [certipy’s README](https://github.com/ly4k/Certipy/tree/main?tab=readme-ov-file#golden-certificates):
> If the KDC returns KDC_ERR_CLIENT_NOT_TRUSTED, it means that the forging was not correct. This usually happens because of a missing certificate revocation list (CRL) in the certificate.

To save others some time and frustration, it may be useful to add a hint about this into the README.